### PR TITLE
Improve AccessTokenFilter handling

### DIFF
--- a/src/main/java/com/knockbook/backend/config/AccessTokenFilter.java
+++ b/src/main/java/com/knockbook/backend/config/AccessTokenFilter.java
@@ -26,22 +26,22 @@ public class AccessTokenFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
-                                    FilterChain chain)
+                                    FilterChain filterChain)
             throws ServletException, IOException {
 
         if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
-            chain.doFilter(request, response);
+            filterChain.doFilter(request, response);
             return;
         }
 
         if (SecurityContextHolder.getContext().getAuthentication() != null) {
-            chain.doFilter(request, response);
+            filterChain.doFilter(request, response);
             return;
         }
 
         final var header = request.getHeader("Authorization");
         if (header == null || !header.startsWith("Bearer ")) {
-            chain.doFilter(request, response); // 익명으로 진행
+            filterChain.doFilter(request, response); // 익명으로 진행
             return;
         }
 
@@ -55,7 +55,7 @@ public class AccessTokenFilter extends OncePerRequestFilter {
             auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
             SecurityContextHolder.getContext().setAuthentication(auth);
 
-            chain.doFilter(request, response);
+            filterChain.doFilter(request, response);
         } catch (ParseException | JOSEException e) {
             SecurityContextHolder.clearContext();
             writeProblem401(response, request);

--- a/src/main/java/com/knockbook/backend/config/AccessTokenFilter.java
+++ b/src/main/java/com/knockbook/backend/config/AccessTokenFilter.java
@@ -6,9 +6,9 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -19,27 +19,69 @@ import java.util.List;
 @Component
 public class AccessTokenFilter extends OncePerRequestFilter {
 
-    @Autowired
-    private JWTComponent jwtComponent;
+    private final JWTComponent jwtComponent;
+
+    public AccessTokenFilter(JWTComponent jwtComponent) {
+        this.jwtComponent = jwtComponent;
+    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
-                                    FilterChain filterChain)
+                                    FilterChain chain)
             throws ServletException, IOException {
-        final var header = request.getHeader("Authorization");
-        if (header != null && header.startsWith("Bearer ")) {
-            final var jws = header.substring(7);
-            final var audience = JWTComponent.Audience.ACCESS_TOKEN_HANDLER;
-            try {
-                final var claims = jwtComponent.parseJWS(jws, audience);
-                final var subject = claims.getSubject();
-                final var auth = new UsernamePasswordAuthenticationToken(subject, null, List.of());
-                SecurityContextHolder.getContext().setAuthentication(auth);
-            } catch (ParseException | JOSEException e) {
-                throw new RuntimeException(e);
-            }
+
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+            chain.doFilter(request, response);
+            return;
         }
-        filterChain.doFilter(request, response);
+
+        if (SecurityContextHolder.getContext().getAuthentication() != null) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        final var header = request.getHeader("Authorization");
+        if (header == null || !header.startsWith("Bearer ")) {
+            chain.doFilter(request, response); // 익명으로 진행
+            return;
+        }
+
+        final var jws = header.substring(7);
+
+        try {
+            final var claims = jwtComponent.parseJWS(jws, JWTComponent.Audience.ACCESS_TOKEN_HANDLER);
+            final var subject = claims.getSubject();
+
+            final var auth = new UsernamePasswordAuthenticationToken(subject, null, List.of());
+            auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(auth);
+
+            chain.doFilter(request, response);
+        } catch (ParseException | JOSEException e) {
+            SecurityContextHolder.clearContext();
+            writeProblem401(response, request);
+        }
+    }
+
+    private void writeProblem401(HttpServletResponse response,
+                                 HttpServletRequest request)
+            throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+
+        final var body = """
+        {
+          "type": "about:blank",
+          "title": "Unauthorized",
+          "status": 401,
+          "detail": "Invalid or expired access token",
+          "instance": "%s"
+        }
+        """.formatted(request.getRequestURI());
+
+        response.getWriter().write(body);
+        response.getWriter().flush();
     }
 }
+

--- a/src/main/java/com/knockbook/backend/config/AccessTokenFilter.java
+++ b/src/main/java/com/knockbook/backend/config/AccessTokenFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
@@ -19,7 +20,8 @@ import java.util.List;
 @Component
 public class AccessTokenFilter extends OncePerRequestFilter {
 
-    private final JWTComponent jwtComponent;
+    @Autowired
+    private JWTComponent jwtComponent;
 
     public AccessTokenFilter(JWTComponent jwtComponent) {
         this.jwtComponent = jwtComponent;

--- a/src/main/java/com/knockbook/backend/config/AccessTokenFilter.java
+++ b/src/main/java/com/knockbook/backend/config/AccessTokenFilter.java
@@ -23,10 +23,6 @@ public class AccessTokenFilter extends OncePerRequestFilter {
     @Autowired
     private JWTComponent jwtComponent;
 
-    public AccessTokenFilter(JWTComponent jwtComponent) {
-        this.jwtComponent = jwtComponent;
-    }
-
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,

--- a/src/main/java/com/knockbook/backend/config/SecurityConfig.java
+++ b/src/main/java/com/knockbook/backend/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.knockbook.backend.config;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -24,6 +25,7 @@ public class SecurityConfig {
                 .cors(Customizer.withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/auth/local/**").permitAll()
                         .requestMatchers("/auth/token/**").permitAll()
                         .requestMatchers("/db-ping").permitAll()
@@ -42,7 +44,7 @@ public class SecurityConfig {
         ));
         corsConfig.setAllowedMethods(List.of("GET","POST","PUT","PATCH","DELETE","OPTIONS"));
         corsConfig.setAllowedHeaders(List.of("*"));
-        corsConfig.setAllowCredentials(false);
+        corsConfig.setAllowCredentials(true);
         corsConfig.setMaxAge(3600L);
 
         UrlBasedCorsConfigurationSource src = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/knockbook/backend/service/BookService.java
+++ b/src/main/java/com/knockbook/backend/service/BookService.java
@@ -1,10 +1,7 @@
 package com.knockbook.backend.service;
 
 import com.knockbook.backend.domain.Book;
-import com.knockbook.backend.repository.BookCategoryRepository;
 import com.knockbook.backend.repository.BookRepository;
-import com.knockbook.backend.repository.BookSubcategoryRepository;
-import jakarta.persistence.EntityNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,18 +13,12 @@ public class BookService {
     @Autowired
     private BookRepository bookRepository;
 
-    @Autowired
-    private BookCategoryRepository categoryRepository;
-
-    @Autowired
-    private BookSubcategoryRepository subcategoryRepository;
-
     public Page<Book> getBooksByCategory(
             String categoryCodeName, String subcategoryCodeName, Pageable pageable,
             String sortBy, String order, Integer maxPrice, Integer minPrice) {
 
         // BookRepository에 ID 전달 → 페이징 결과(Page<Book>) 반환
-        return bookRepository.findByCategory(categoryCodeName, subcategoryCodeName, pageable, sortBy, order, maxPrice, minPrice);
+        return bookRepository.findByCategory(categoryCodeName, subcategoryCodeName, pageable,
+                sortBy, order, maxPrice, minPrice);
     }
-
 }


### PR DESCRIPTION
This patch would:
- skip OPTIONS preflight requests to allow CORS flow
- return 401 with ProblemDetails JSON on token parse failure instead of throwing RuntimeException