### PR TITLE
Allow unauthenticated acess to email registration endpoint

### DIFF
--- a/src/main/java/com/knockbook/backend/config/AccessTokenFilter.java
+++ b/src/main/java/com/knockbook/backend/config/AccessTokenFilter.java
@@ -34,6 +34,12 @@ public class AccessTokenFilter extends OncePerRequestFilter {
             return;
         }
 
+        final var uri = request.getRequestURI();
+        if (uri.startsWith("/auth/local/") || uri.startsWith("/auth/token/")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         if (SecurityContextHolder.getContext().getAuthentication() != null) {
             filterChain.doFilter(request, response);
             return;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,5 +35,6 @@ spring.mail.default-encoding=UTF-8
 
 # log4j2 Config
 logging.config=classpath:log4j2.properties
+logging.level.org.springframework.security=DEBUG
 
 spring.security.oauth2.resourceserver.jwt.issuer-uri: knockbook


### PR DESCRIPTION
This patch would:
- updated AccessTokenFilter to bypass /auth/local/**, /auth/token/**
- added Spring Security DEBUG logging for easier access-denied troubleshooting