### PR TITLE
Add password change workflow and expose endpoint

### DIFF
--- a/src/main/java/com/knockbook/backend/controller/UserController.java
+++ b/src/main/java/com/knockbook/backend/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.knockbook.backend.controller;
 
 import com.knockbook.backend.domain.User;
+import com.knockbook.backend.dto.ChangePasswordRequest;
 import com.knockbook.backend.dto.UserResponse;
 import com.knockbook.backend.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,7 +36,7 @@ public class UserController {
 
     @PreAuthorize("#userId == authentication.name")
     @PutMapping("/{userId}")
-    public ResponseEntity<Void> updateUser(
+    public ResponseEntity<Void> updateProfile(
             @PathVariable("userId") String userId,
             @RequestParam(required = false) String displayName,
             @RequestParam(required = false) String avatarUrl,
@@ -48,7 +49,17 @@ public class UserController {
                 .mbti(mbti)
                 .favoriteBookCategories(favoriteBookCategories)
                 .build();
-        userService.updateUserProfile(patch);
+        userService.updateProfile(patch);
+        return ResponseEntity.noContent().build(); // 204
+    }
+
+    @PreAuthorize("#userId == authentication.name")
+    @PutMapping("/{userId}/password")
+    public ResponseEntity<Void> changePassword(
+            @PathVariable("userId") String userId,
+            @RequestBody ChangePasswordRequest req
+    ) {
+        userService.changePassword(Long.valueOf(userId), req.getPassword());
         return ResponseEntity.noContent().build(); // 204
     }
 }

--- a/src/main/java/com/knockbook/backend/dto/ChangePasswordRequest.java
+++ b/src/main/java/com/knockbook/backend/dto/ChangePasswordRequest.java
@@ -1,0 +1,21 @@
+package com.knockbook.backend.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class ChangePasswordRequest {
+    @NotBlank
+    @Size(min = 8, max = 12)
+    @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&+=])[A-Za-z\\d@$!%*?&+=]{8,12}$",
+            message = "Password must be 8-12 characters long and include at least one letter, one digit," +
+                    " and one special character (@$!%*?&)."
+    )
+    private String password;
+}

--- a/src/main/java/com/knockbook/backend/repository/CredentialRepository.java
+++ b/src/main/java/com/knockbook/backend/repository/CredentialRepository.java
@@ -10,4 +10,7 @@ public interface CredentialRepository {
                       final String passwordHash);
 
     Optional<Credential> findByIdentityId(final Long identityId);
+
+    void update(final Long identityId,
+                final String passwordHash);
 }

--- a/src/main/java/com/knockbook/backend/repository/CredentialRepositoryImpl.java
+++ b/src/main/java/com/knockbook/backend/repository/CredentialRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.knockbook.backend.domain.Credential;
 import com.knockbook.backend.entity.CredentialEntity;
 import com.knockbook.backend.entity.CredentialEntity_;
 import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -50,5 +51,17 @@ public class CredentialRepositoryImpl implements CredentialRepository {
                         .passwordHash(entity.getPasswordHash())
                         .passwordUpdatedAt(entity.getPasswordUpdatedAt())
                         .build());
+    }
+
+    @Override
+    @Transactional
+    public void update(Long identityId, String passwordHash) {
+        final var cb = em.getCriteriaBuilder();
+        final var cu = cb.createCriteriaUpdate(CredentialEntity.class);
+        final var r = cu.from(CredentialEntity.class);
+        cu.set(r.get(CredentialEntity_.passwordHash), passwordHash)
+                .where(cb.equal(r.get(CredentialEntity_.identityId), identityId));
+        em.createQuery(cu).executeUpdate();
+        em.clear();
     }
 }

--- a/src/main/java/com/knockbook/backend/service/UserService.java
+++ b/src/main/java/com/knockbook/backend/service/UserService.java
@@ -62,7 +62,18 @@ public class UserService {
                 .orElseThrow(() -> new UserNotFoundException(id));
     }
 
-    public void updateUserProfile(final User patch) {
+    public void changePassword(final Long id, final String password) {
+        final var user = userRepository.findById(id)
+                .orElseThrow(() -> new UserNotFoundException(id));
+        final var email = user.getEmail();
+        final var identity = identityRepository.findByProviderCodeAndSubject("local", email)
+                .orElseThrow(() -> new IdentityNotFoundException(email));
+        final var identityId = identity.getId();
+        final var hash = passwordEncoder.encode(password);
+        credentialRepository.update(identityId, hash);
+    }
+
+    public void updateProfile(final User patch) {
         userRepository.update(patch);
     }
 }


### PR DESCRIPTION
This patch would:
- implemented service layer for password change
- added update method in CredentialRepository
- exposed /users/{userId}/password controller endpoint